### PR TITLE
パラメータをfixedのチェックを外しても1本しか表示されないバグを修正

### DIFF
--- a/src/animation_control.ts
+++ b/src/animation_control.ts
@@ -356,7 +356,8 @@ export function dfs_each_line(
         ++phase_index.index;
         phase = phase_index.phase;
       }
-      const finished = search_next_child(
+      let finished: boolean;
+      [current_param_idx, finished] = search_next_child(
         phase_index_array,
         axes,
         line,
@@ -392,7 +393,7 @@ function search_next_child(
   current_line_vec: { vec: THREE.Vector3; isPP: boolean }[],
   phase_index: { phase: HydatPhase; index: number },
   phase: HydatPhase
-) {
+): [number, boolean] {
   for (;;) {
     // search next child to plot
     for (; /* restart searching */ phase_index.index < phase.children.length; phase_index.index++) {
@@ -422,9 +423,9 @@ function search_next_child(
               current_line_vec
             );
           });
-          return true;
+          return [current_param_idx, true];
         }
-        return false; // go to child
+        return [current_param_idx, false]; // go to child
       }
     }
 
@@ -436,12 +437,12 @@ function search_next_child(
         // Plot is completed.
         line.plotting = false;
         checkAndStopPreloader();
-        return true;
+        return [current_param_idx, true];
       } else {
         // 次のparameter conditionで探索しなおす
         ++current_param_idx;
         phase_index_array[0].index = 0;
-        break;
+        return [current_param_idx, false];
       }
     } else {
       // go to parent phase


### PR DESCRIPTION
[11e7507](https://github.com/HydLa/webHydLa/commit/11e750773f3e5cd9ff43a10c0b7effa473d4c7c5)での分割で，パラメータを含む例題でfixedのチェックを外しても1本しか描画されなくなっていた．
原因は更新されるインデックスを値渡ししていたこと．