### PR TITLE
辞書をオブジェクトからマップにする

### DIFF
--- a/src/__tests__/parse.test.ts
+++ b/src/__tests__/parse.test.ts
@@ -1,102 +1,111 @@
-import { parse, Constant } from '../parse';
+import { parse, Env, Constant } from '../parse';
 
 test('Constant(1)=1', () => {
   const one = new Constant(1);
-  expect(one.getValue({})).toBe(1);
+  expect(one.getValue(new Map())).toBe(1);
 });
 
 test('1+1=2', () => {
-  expect(parse('1+1').getValue({})).toBe(2);
+  expect(parse('1+1').getValue(new Map())).toBe(2);
 });
 
 test('1*1=1', () => {
-  expect(parse('1*1').getValue({})).toBe(1);
+  expect(parse('1*1').getValue(new Map())).toBe(1);
 });
 
 test('1-1=0', () => {
-  expect(parse('1-1').getValue({})).toBe(0);
+  expect(parse('1-1').getValue(new Map())).toBe(0);
 });
 
 test('1/1=1', () => {
-  expect(parse('1/1').getValue({})).toBe(1);
+  expect(parse('1/1').getValue(new Map())).toBe(1);
 });
 
 test('1=1', () => {
-  expect(parse('1').getValue({})).toBe(1);
+  expect(parse('1').getValue(new Map())).toBe(1);
 });
 
 test('(1+1)=2', () => {
-  expect(parse('(1+1)').getValue({})).toBe(2);
+  expect(parse('(1+1)').getValue(new Map())).toBe(2);
 });
 
 test('(1*1)/1=1', () => {
-  expect(parse('(1*1)/1').getValue({})).toBe(1);
+  expect(parse('(1*1)/1').getValue(new Map())).toBe(1);
 });
 
 test('1^1=1', () => {
-  expect(parse('1^1').getValue({})).toBe(1);
+  expect(parse('1^1').getValue(new Map())).toBe(1);
 });
 
 test('-1=-1', () => {
-  expect(parse('-1').getValue({})).toBe(-1);
+  expect(parse('-1').getValue(new Map())).toBe(-1);
 });
 
 test('-1+-1=-2', () => {
-  expect(parse('-1+-1').getValue({})).toBe(-2);
+  expect(parse('-1+-1').getValue(new Map())).toBe(-2);
 });
 
 test('Infinity=Infinity', () => {
-  expect(parse('Infinity').getValue({})).toBe(Infinity);
+  expect(parse('Infinity').getValue(new Map())).toBe(Infinity);
 });
 
 test('Pi=Math.PI', () => {
-  expect(parse('Pi').getValue({})).toBe(Math.PI);
+  expect(parse('Pi').getValue(new Map())).toBe(Math.PI);
 });
 
 test('E=Math.E', () => {
-  expect(parse('E').getValue({})).toBe(Math.E);
+  expect(parse('E').getValue(new Map())).toBe(Math.E);
 });
 
 test('t=t', () => {
-  expect(parse('t').getValue({ ['t']: new Constant(1) })).toBe(1);
+  const env: Env = new Map([['t', new Constant(1)]]);
+  expect(parse('t').getValue(env)).toBe(1);
 });
 
 test('timer=timer', () => {
-  expect(parse('timer').getValue({ ['timer']: new Constant(1) })).toBe(1);
+  const env: Env = new Map([['timer', new Constant(1)]]);
+  expect(parse('timer').getValue(env)).toBe(1);
 });
 
 test('p[x,0,1]=p[x, 0, 1]', () => {
-  expect(parse('p[x,0,1]').getValue({ ['p[x, 0, 1]']: new Constant(1) })).toBe(1);
+  const env: Env = new Map([['p[x, 0, 1]', new Constant(1)]]);
+  expect(parse('p[x,0,1]').getValue(env)).toBe(1);
 });
 
 test('x0=x0', () => {
-  expect(parse('x0').getValue({ ['x0']: new Constant(1) })).toBe(1);
+  const env: Env = new Map([['x0', new Constant(1)]]);
+  expect(parse('x0').getValue(env)).toBe(1);
 });
 
 test('Log[10]=Math.log(10)', () => {
-  expect(parse('Log[10]').getValue({})).toBe(Math.log(10));
+  expect(parse('Log[10]').getValue(new Map())).toBe(Math.log(10));
 });
 
 test('Sin[10]=Math.sin(10)', () => {
-  expect(parse('Sin[10]').getValue({})).toBe(Math.sin(10));
+  expect(parse('Sin[10]').getValue(new Map())).toBe(Math.sin(10));
 });
 
 test('Cos[10]=Math.cos(10)', () => {
-  expect(parse('Cos[10]').getValue({})).toBe(Math.cos(10));
+  expect(parse('Cos[10]').getValue(new Map())).toBe(Math.cos(10));
 });
 
 test('Tan[10]=Math.tan(10)', () => {
-  expect(parse('Tan[10]').getValue({})).toBe(Math.tan(10));
+  expect(parse('Tan[10]').getValue(new Map())).toBe(Math.tan(10));
 });
 
 test('Floor[E]=2', () => {
-  expect(parse('Floor[E]').getValue({})).toBe(2);
+  expect(parse('Floor[E]').getValue(new Map())).toBe(2);
 });
 
 test('complicated', () => {
+  const env: Env = new Map([
+    ['t', new Constant(1)],
+    ['p[v, 0, 1]', new Constant(1)],
+    ['p[ht, 0, 1]', new Constant(1)],
+  ]);
   expect(
     parse(
       '(t * (-1250) + 125 * p[v, 0, 1] + 613 * (20 * p[ht, 0, 1] + p[v, 0, 1] ^ 2) ^ (1/2))*(t*(-250)+25*p[v, 0, 1]+97*(20*p[ht, 0, 1]+p[v, 0, 1]^2)^(1/2))*(-1)/62500'
-    ).getValue({ ['t']: new Constant(1), ['p[v, 0, 1]']: new Constant(1), ['p[ht, 0, 1]']: new Constant(1) })
+    ).getValue(env)
   ).toBe(-5.914890792978555);
 });

--- a/src/animation_control.ts
+++ b/src/animation_control.ts
@@ -143,7 +143,6 @@ function divideParameter(parameter_map: Map<string, HydatParameter>) {
       for (let i = 0; i < now_parameter_condition_list.length; i++) {
         for (let j = 0; j < div; j++) {
           const parameter_value = lb + j * deltaP;
-          console.log(now_parameter_condition_list[i]);
           const tmp_obj = new Map([...now_parameter_condition_list[i]]);
           tmp_obj.set(parameter_name, new Constant(parameter_value));
           next_parameter_condition_list.push(tmp_obj);
@@ -483,27 +482,23 @@ export function resetAnimation(line: PlotLine) {
 }
 
 /** parameter_condition_listの値がparameter_mapsの範囲内にあるか */
-function check_parameter_condition(parameter_maps: Map<string, HydatParameter>[], parameter_condition_list: ParamCond) {
+function check_parameter_condition(parameter_maps: Map<string, HydatParameter>[], parameter_condition: ParamCond) {
   const epsilon = 0.0001;
   for (const map of parameter_maps) {
     let included = true;
     for (const [key, p] of map) {
-      const c = parameter_condition_list.get(key);
+      const c = parameter_condition.get(key);
       if (c === undefined) continue;
       if (p instanceof HydatParameterInterval) {
-        const lb = p.lower_bound.value.getValue(parameter_condition_list);
-        const ub = p.upper_bound.value.getValue(parameter_condition_list);
-        if (
-          !(
-            lb <= c.getValue(parameter_condition_list) + epsilon && ub >= c.getValue(parameter_condition_list) - epsilon
-          )
-        ) {
+        const lb = p.lower_bound.value.getValue(parameter_condition);
+        const ub = p.upper_bound.value.getValue(parameter_condition);
+        if (!(lb <= c.getValue(parameter_condition) + epsilon && ub >= c.getValue(parameter_condition) - epsilon)) {
           included = false;
         }
       } else if (
         !(
-          p.unique_value.getValue(parameter_condition_list) <= c.getValue(parameter_condition_list) + epsilon &&
-          p.unique_value.getValue(parameter_condition_list) >= c.getValue(parameter_condition_list) - epsilon
+          p.unique_value.getValue(parameter_condition) <= c.getValue(parameter_condition) + epsilon &&
+          p.unique_value.getValue(parameter_condition) >= c.getValue(parameter_condition) - epsilon
         )
       ) {
         included = false;

--- a/src/animation_control.ts
+++ b/src/animation_control.ts
@@ -5,7 +5,7 @@ import { graphControl, renderGraph_three_js } from './graph_control';
 import { HydatParameter, HydatParameterInterval, HydatPhase } from './hydat';
 import { RGB, Triplet } from './plot_utils';
 import { HydatControl } from './hydat_control';
-import { parse, Construct, Constant } from './parse';
+import { parse, ParamCond, Construct, Constant } from './parse';
 import { MultiBiMap } from './animation_utils';
 import { PlotSettingsControl } from './plot_settings';
 import { checkAndStopPreloader, phase_to_line_vectors, resetPlotStartTime } from './plot_control';
@@ -120,14 +120,14 @@ function add_plot(line: PlotLine) {
 }
 
 function divideParameter(parameter_map: Map<string, HydatParameter>) {
-  let now_parameter_condition_list: { [key: string]: Constant }[] = [{}];
+  let now_parameter_condition_list: ParamCond[] = [new Map()];
 
   for (const parameter_name of parameter_map.keys()) {
     const setting = PlotSettingsControl.plot_settings.parameter_condition!.get(parameter_name)!;
     if (setting.fixed) {
       for (let i = 0; i < now_parameter_condition_list.length; i++) {
         const parameter_value = setting.value;
-        now_parameter_condition_list[i][parameter_name] = new Constant(parameter_value);
+        now_parameter_condition_list[i].set(parameter_name, new Constant(parameter_value));
       }
     } else {
       const lb = setting.min_value;
@@ -143,8 +143,9 @@ function divideParameter(parameter_map: Map<string, HydatParameter>) {
       for (let i = 0; i < now_parameter_condition_list.length; i++) {
         for (let j = 0; j < div; j++) {
           const parameter_value = lb + j * deltaP;
-          const tmp_obj = $.extend(true, {}, now_parameter_condition_list[i]); // deep copy
-          tmp_obj[parameter_name] = new Constant(parameter_value);
+          console.log(now_parameter_condition_list[i]);
+          const tmp_obj = new Map([...now_parameter_condition_list[i]]);
+          tmp_obj.set(parameter_name, new Constant(parameter_value));
           next_parameter_condition_list.push(tmp_obj);
         }
       }
@@ -321,7 +322,7 @@ export function dfs_each_line(
   width: number,
   color: number[],
   dt: number,
-  parameter_condition_list: { [key: string]: Constant }[],
+  parameter_condition_list: ParamCond[],
   current_param_idx: number,
   current_line_vec: { vec: THREE.Vector3; isPP: boolean }[]
 ) {
@@ -387,7 +388,7 @@ function search_next_child(
   width: number,
   color: number[],
   dt: number,
-  parameter_condition_list: { [key: string]: Constant }[],
+  parameter_condition_list: ParamCond[],
   current_param_idx: number,
   current_line_vec: { vec: THREE.Vector3; isPP: boolean }[],
   phase_index: { phase: HydatPhase; index: number },
@@ -482,15 +483,12 @@ export function resetAnimation(line: PlotLine) {
 }
 
 /** parameter_condition_listの値がparameter_mapsの範囲内にあるか */
-function check_parameter_condition(
-  parameter_maps: Map<string, HydatParameter>[],
-  parameter_condition_list: { [key: string]: Constant }
-) {
+function check_parameter_condition(parameter_maps: Map<string, HydatParameter>[], parameter_condition_list: ParamCond) {
   const epsilon = 0.0001;
   for (const map of parameter_maps) {
     let included = true;
     for (const [key, p] of map) {
-      const c = parameter_condition_list[key];
+      const c = parameter_condition_list.get(key);
       if (c === undefined) continue;
       if (p instanceof HydatParameterInterval) {
         const lb = p.lower_bound.value.getValue(parameter_condition_list);

--- a/src/animation_control.ts
+++ b/src/animation_control.ts
@@ -123,7 +123,7 @@ function divideParameter(parameter_map: Map<string, HydatParameter>) {
   let now_parameter_condition_list: { [key: string]: Constant }[] = [{}];
 
   for (const parameter_name of parameter_map.keys()) {
-    const setting = PlotSettingsControl.plot_settings.parameter_condition![parameter_name];
+    const setting = PlotSettingsControl.plot_settings.parameter_condition!.get(parameter_name)!;
     if (setting.fixed) {
       for (let i = 0; i < now_parameter_condition_list.length; i++) {
         const parameter_value = setting.value;

--- a/src/dat_gui_control.ts
+++ b/src/dat_gui_control.ts
@@ -116,9 +116,8 @@ export class DatGUIControl {
       this.parameter_folder.remove(item);
     }
     this.parameter_items = [];
-    DatGUIControl.plot_settings.parameter_condition = {};
+    DatGUIControl.plot_settings.parameter_condition = new Map();
     for (const [key, par] of pars) {
-      const key_copy = key;
       if (par instanceof HydatParameterPoint) return;
 
       const lower = par.lower_bound.value.getValue({});
@@ -131,24 +130,27 @@ export class DatGUIControl {
       const max_par_value = isFinite(upper) ? upper : lower + 100;
       const step = (max_par_value - min_par_value) / 100;
 
-      DatGUIControl.plot_settings.parameter_condition[key] = new ParameterCondition(min_par_value, max_par_value);
+      DatGUIControl.plot_settings.parameter_condition.set(key, new ParameterCondition(min_par_value, max_par_value));
 
       const parameter_item = this.parameter_folder
-        .add(DatGUIControl.plot_settings.parameter_condition[key], 'value', min_par_value, max_par_value)
+        .add(DatGUIControl.plot_settings.parameter_condition.get(key)!, 'value', min_par_value, max_par_value)
         .name(key);
       parameter_item.onChange(() => {
         replotAll();
       });
       parameter_item.step(step);
 
-      const mode_item = this.parameter_folder.add(DatGUIControl.plot_settings.parameter_condition[key], 'fixed');
-      const mode_item_range = this.parameter_folder.add(DatGUIControl.plot_settings.parameter_condition[key], 'range');
+      const mode_item = this.parameter_folder.add(DatGUIControl.plot_settings.parameter_condition.get(key)!, 'fixed');
+      const mode_item_range = this.parameter_folder.add(
+        DatGUIControl.plot_settings.parameter_condition.get(key)!,
+        'range'
+      );
       this.parameter_items.push(mode_item);
       this.parameter_items.push(mode_item_range);
       this.parameter_items.push(parameter_item);
 
       mode_item.onChange(function () {
-        if (!DatGUIControl.plot_settings.parameter_condition![key_copy].fixed) {
+        if (!DatGUIControl.plot_settings.parameter_condition!.get(key)!.fixed) {
           parameter_item.min(1).max(100).step(1).setValue(5);
         } else {
           parameter_item
@@ -160,7 +162,7 @@ export class DatGUIControl {
         replotAll();
       });
       mode_item_range.onChange(() => {
-        graphControl.range_mode = DatGUIControl.plot_settings.parameter_condition![key_copy].range;
+        graphControl.range_mode = DatGUIControl.plot_settings.parameter_condition!.get(key)!.range;
       });
     }
     if (pars.size > 0) this.parameter_folder.open();

--- a/src/dat_gui_control.ts
+++ b/src/dat_gui_control.ts
@@ -120,8 +120,8 @@ export class DatGUIControl {
     for (const [key, par] of pars) {
       if (par instanceof HydatParameterPoint) return;
 
-      const lower = par.lower_bound.value.getValue({});
-      const upper = par.upper_bound.value.getValue({});
+      const lower = par.lower_bound.value.getValue(new Map());
+      const upper = par.upper_bound.value.getValue(new Map());
       if (!isFinite(lower) && !isFinite(upper)) {
         throw new Error('Error: at least one of lower_bound and upper_bound must be finite.');
       }

--- a/src/hydat.ts
+++ b/src/hydat.ts
@@ -61,7 +61,7 @@ export class Hydat {
 export interface HydatRaw {
   name: string;
   first_phases: HydatPhaseRaw[];
-  parameters: { [key: string]: HydatParameterRaw };
+  parameters: { [key: string]: HydatParameterRaw }; // Mapにしない（JSON.parseの結果を格納するため）
   variables: string[];
 }
 
@@ -107,8 +107,8 @@ export class HydatPhase {
 interface HydatPhaseRaw {
   type: string;
   time: HydatTimeRaw;
-  variable_map: { [key: string]: HydatVariableRaw };
-  parameter_maps: { [key: string]: HydatParameterRaw }[];
+  variable_map: { [key: string]: HydatVariableRaw }; // Mapにしない（JSON.parseの結果を格納するため）
+  parameter_maps: { [key: string]: HydatParameterRaw }[]; // Mapにしない（JSON.parseの結果を格納するため）
   children: HydatPhaseRaw[];
   simulation_state: string;
 }

--- a/src/hydat.ts
+++ b/src/hydat.ts
@@ -1,4 +1,4 @@
-import { parse, Construct, Constant, Plus } from './parse';
+import { parse, Env, Construct, Constant, Plus } from './parse';
 
 const isHydatParameterPointRaw = (raw: HydatParameterRaw): raw is HydatParameterPointRaw => {
   return (raw as HydatParameterPointRaw).unique_value !== undefined;
@@ -68,7 +68,7 @@ export interface HydatRaw {
 export class HydatPhase {
   type: 'PP' | 'IP';
   time: HydatTime;
-  variable_map: { [key: string]: Construct };
+  variable_map: Env;
   parameter_maps: Map<string, HydatParameter>[];
   children: HydatPhase[];
   simulation_state: string;
@@ -84,12 +84,12 @@ export class HydatPhase {
       this.time = new HydatTimeIP(phase.time.start_time, phase.time.end_time);
     }
 
-    this.variable_map = {};
+    this.variable_map = new Map();
     for (const key in phase.variable_map) {
       if (phase.variable_map[key].unique_value === undefined) {
         throw new HydatException(`webHydLa doesn't support ununique value in variable maps for ${key}`);
       }
-      this.variable_map[key] = parse(phase.variable_map[key].unique_value /*, phase.variable_map*/);
+      this.variable_map.set(key, parse(phase.variable_map[key].unique_value));
     }
 
     this.parameter_maps = [];

--- a/src/parse.ts
+++ b/src/parse.ts
@@ -231,11 +231,12 @@ export function parse(value_str: string) {
   return expression(s, 0)[0];
 }
 
-// TODO: { [key: string]: Construct } を Map<string, Construct> で置き換える
+export type Env = Map<string, Construct>;
+export type ParamCond = Map<string, Constant>;
 
 export interface Construct {
   toString(): string;
-  getValue(env: { [key: string]: Construct }): number;
+  getValue(env: Env): number;
 }
 
 interface UnaryConstruct extends Construct {
@@ -252,7 +253,7 @@ export class Plus implements BinaryConstruct {
   toString() {
     return `(${this.lhs.toString()} + ${this.rhs.toString()})`;
   }
-  getValue(env: { [key: string]: Construct }) {
+  getValue(env: Env) {
     return this.lhs.getValue(env) + this.rhs.getValue(env);
   }
 }
@@ -262,7 +263,7 @@ class Subtract implements BinaryConstruct {
   toString() {
     return `(${this.lhs.toString()} - ${this.rhs.toString()})`;
   }
-  getValue(env: { [key: string]: Construct }) {
+  getValue(env: Env) {
     return this.lhs.getValue(env) - this.rhs.getValue(env);
   }
 }
@@ -272,7 +273,7 @@ class Multiply implements BinaryConstruct {
   toString() {
     return `${this.lhs.toString()} * ${this.rhs.toString()}`;
   }
-  getValue(env: { [key: string]: Construct }) {
+  getValue(env: Env) {
     return this.lhs.getValue(env) * this.rhs.getValue(env);
   }
 }
@@ -282,7 +283,7 @@ class Divide implements BinaryConstruct {
   toString() {
     return `${this.lhs.toString()} / ${this.rhs.toString()}`;
   }
-  getValue(env: { [key: string]: Construct }) {
+  getValue(env: Env) {
     return this.lhs.getValue(env) / this.rhs.getValue(env);
   }
 }
@@ -292,7 +293,7 @@ class Power implements BinaryConstruct {
   toString() {
     return `${this.lhs.toString()} ^ ${this.rhs.toString()}`;
   }
-  getValue(env: { [key: string]: Construct }) {
+  getValue(env: Env) {
     return Math.pow(this.lhs.getValue(env), this.rhs.getValue(env));
   }
 }
@@ -302,7 +303,7 @@ export class Constant implements Construct {
   toString() {
     return this.val.toString();
   }
-  getValue(env: { [key: string]: Construct }) {
+  getValue(env: Env) {
     return this.val;
   }
 }
@@ -312,9 +313,9 @@ class Variable implements Construct {
   toString() {
     return this.name;
   }
-  getValue(env: { [key: string]: Construct }) {
-    if (env[this.name] == undefined) throw new Error(`${this.name} is not defined`);
-    return env[this.name].getValue(env);
+  getValue(env: Env) {
+    if (env.get(this.name) == undefined) throw new Error(`${this.name} is not defined`);
+    return env.get(this.name)!.getValue(env);
   }
 }
 
@@ -323,7 +324,7 @@ class Log implements UnaryConstruct {
   toString() {
     return `log(${this.arg.toString()})`;
   }
-  getValue(env: { [key: string]: Construct }) {
+  getValue(env: Env) {
     return Math.log(this.arg.getValue(env));
   }
 }
@@ -333,7 +334,7 @@ class Sin implements UnaryConstruct {
   toString() {
     return `sin(${this.arg.toString()})`;
   }
-  getValue(env: { [key: string]: Construct }) {
+  getValue(env: Env) {
     return Math.sin(this.arg.getValue(env));
   }
 }
@@ -343,7 +344,7 @@ class Cos implements UnaryConstruct {
   toString() {
     return `cos(${this.arg.toString()})`;
   }
-  getValue(env: { [key: string]: Construct }) {
+  getValue(env: Env) {
     return Math.cos(this.arg.getValue(env));
   }
 }
@@ -353,7 +354,7 @@ class Tan implements UnaryConstruct {
   toString() {
     return `tan(${this.arg.toString()})`;
   }
-  getValue(env: { [key: string]: Construct }) {
+  getValue(env: Env) {
     return Math.tan(this.arg.getValue(env));
   }
 }
@@ -363,7 +364,7 @@ class ArcSin implements UnaryConstruct {
   toString() {
     return `asin(${this.arg.toString()})`;
   }
-  getValue(env: { [key: string]: Construct }) {
+  getValue(env: Env) {
     return Math.asin(this.arg.getValue(env));
   }
 }
@@ -373,7 +374,7 @@ class ArcCos implements UnaryConstruct {
   toString() {
     return `acos(${this.arg.toString()})`;
   }
-  getValue(env: { [key: string]: Construct }) {
+  getValue(env: Env) {
     return Math.acos(this.arg.getValue(env));
   }
 }
@@ -383,7 +384,7 @@ class ArcTan implements UnaryConstruct {
   toString() {
     return `atan(${this.arg.toString()})`;
   }
-  getValue(env: { [key: string]: Construct }) {
+  getValue(env: Env) {
     return Math.atan(this.arg.getValue(env));
   }
 }
@@ -393,7 +394,7 @@ class Sinh implements UnaryConstruct {
   toString() {
     return `sinh(${this.arg.toString()})`;
   }
-  getValue(env: { [key: string]: Construct }) {
+  getValue(env: Env) {
     return Math.sinh(this.arg.getValue(env));
   }
 }
@@ -403,7 +404,7 @@ class Cosh implements UnaryConstruct {
   toString() {
     return `cosh(${this.arg.toString()})`;
   }
-  getValue(env: { [key: string]: Construct }) {
+  getValue(env: Env) {
     return Math.cosh(this.arg.getValue(env));
   }
 }
@@ -413,7 +414,7 @@ class Tanh implements UnaryConstruct {
   toString() {
     return `tanh(${this.arg.toString()})`;
   }
-  getValue(env: { [key: string]: Construct }) {
+  getValue(env: Env) {
     return Math.tanh(this.arg.getValue(env));
   }
 }
@@ -423,7 +424,7 @@ class ArcSinh implements UnaryConstruct {
   toString() {
     return `asinh(${this.arg.toString()})`;
   }
-  getValue(env: { [key: string]: Construct }) {
+  getValue(env: Env) {
     return Math.asinh(this.arg.getValue(env));
   }
 }
@@ -433,7 +434,7 @@ class ArcCosh implements UnaryConstruct {
   toString() {
     return `acosh(${this.arg.toString()})`;
   }
-  getValue(env: { [key: string]: Construct }) {
+  getValue(env: Env) {
     return Math.acosh(this.arg.getValue(env));
   }
 }
@@ -443,7 +444,7 @@ class ArcTanh implements UnaryConstruct {
   toString() {
     return `atanh(${this.arg.toString()})`;
   }
-  getValue(env: { [key: string]: Construct }) {
+  getValue(env: Env) {
     return Math.atanh(this.arg.getValue(env));
   }
 }
@@ -453,7 +454,7 @@ class Floor implements UnaryConstruct {
   toString() {
     return `floor(${this.arg.toString()})`;
   }
-  getValue(env: { [key: string]: Construct }) {
+  getValue(env: Env) {
     return Math.floor(this.arg.getValue(env));
   }
 }
@@ -463,7 +464,7 @@ class Negative implements UnaryConstruct {
   toString() {
     return `-${this.arg.toString()}`;
   }
-  getValue(env: { [key: string]: Construct }) {
+  getValue(env: Env) {
     return -this.arg.getValue(env);
   }
 }

--- a/src/plot_control.ts
+++ b/src/plot_control.ts
@@ -7,7 +7,7 @@ import { Triplet, RGB, ComparableTriplet, Range } from './plot_utils';
 import { Object3D } from 'three';
 import { HydatPhase, HydatTimePP, HydatException } from './hydat';
 import { PlotSettingsControl } from './plot_settings';
-import { Env, ParamCond, Construct, Constant } from './parse';
+import { ParamCond, Construct, Constant } from './parse';
 
 const axisColorBases = new Triplet<RGB>(new RGB(1.0, 0.3, 0.3), new RGB(0.3, 1.0, 0.3), new RGB(0.3, 0.3, 1.0));
 

--- a/src/plot_control.ts
+++ b/src/plot_control.ts
@@ -7,7 +7,7 @@ import { Triplet, RGB, ComparableTriplet, Range } from './plot_utils';
 import { Object3D } from 'three';
 import { HydatPhase, HydatTimePP, HydatException } from './hydat';
 import { PlotSettingsControl } from './plot_settings';
-import { Construct, Constant } from './parse';
+import { Env, ParamCond, Construct, Constant } from './parse';
 
 const axisColorBases = new Triplet<RGB>(new RGB(1.0, 0.3, 0.3), new RGB(0.3, 1.0, 0.3), new RGB(0.3, 0.3, 1.0));
 
@@ -27,7 +27,7 @@ const plotState: PlotState = {
 
 export function phase_to_line_vectors(
   phase: HydatPhase,
-  parameter_condition_list: { [key: string]: Constant },
+  parameter_condition: ParamCond,
   axis: Triplet<Construct>,
   maxDeltaT: number
 ) {
@@ -41,11 +41,10 @@ export function phase_to_line_vectors(
     return line;
   }
 
-  const env: { [key: string]: Construct } = {};
-  $.extend(env, parameter_condition_list, phase.variable_map);
+  const env = new Map([...parameter_condition, ...phase.variable_map]);
 
   if (phase.time instanceof HydatTimePP) {
-    env.t = phase.time.time_point;
+    env.set('t', phase.time.time_point);
     line.push({
       vec: new THREE.Vector3(axis.x.getValue(env), axis.y.getValue(env), axis.z.getValue(env)),
       isPP: true,
@@ -59,13 +58,13 @@ export function phase_to_line_vectors(
     const MIN_STEP = 10; // Minimum step of plotting one IP
     const delta_t = Math.min(maxDeltaT, (end_time - start_time) / MIN_STEP);
     for (t = start_time; t < end_time; t = t + delta_t) {
-      env.t = new Constant(t);
+      env.set('t', new Constant(t));
       line.push({
         vec: new THREE.Vector3(axis.x.getValue(env), axis.y.getValue(env), axis.z.getValue(env)),
         isPP: false,
       });
     }
-    env.t = new Constant(end_time);
+    env.set('t', new Constant(end_time));
     line.push({
       vec: new THREE.Vector3(axis.x.getValue(env), axis.y.getValue(env), axis.z.getValue(env)),
       isPP: false,

--- a/src/plot_line.ts
+++ b/src/plot_line.ts
@@ -5,7 +5,7 @@ import { HydatControl } from './hydat_control';
 import { saveHydatSettingsToStorage } from './storage_control';
 import { Triplet } from './plot_utils';
 import { HydatPhase } from './hydat';
-import { parse, ParamCond, Construct, Constant } from './parse';
+import { parse, ParamCond, Construct } from './parse';
 import { dfs_each_line, resetAnimation } from './animation_control';
 import { setPlotStartTimeIfUnset } from './plot_control';
 

--- a/src/plot_line.ts
+++ b/src/plot_line.ts
@@ -5,7 +5,7 @@ import { HydatControl } from './hydat_control';
 import { saveHydatSettingsToStorage } from './storage_control';
 import { Triplet } from './plot_utils';
 import { HydatPhase } from './hydat';
-import { parse, Construct, Constant } from './parse';
+import { parse, ParamCond, Construct, Constant } from './parse';
 import { dfs_each_line, resetAnimation } from './animation_control';
 import { setPlotStartTimeIfUnset } from './plot_control';
 
@@ -137,5 +137,5 @@ interface PlotInformation {
   width: number;
   color: number[];
   dt: number;
-  parameter_condition_list: { [key: string]: Constant }[];
+  parameter_condition_list: ParamCond[];
 }

--- a/src/plot_settings.ts
+++ b/src/plot_settings.ts
@@ -33,7 +33,7 @@ export class PlotSettings {
   dynamicDraw: boolean;
   animate: boolean;
   seek: number;
-  parameter_condition: { [key: string]: ParameterCondition } | undefined;
+  parameter_condition: Map<string, ParameterCondition> | undefined;
   parameter_condition_seek: ParameterConditionSeek | undefined;
   constructor(obj: any) {
     this.plotInterval = obj?.plotInterval ?? 0.1;


### PR DESCRIPTION
主な変更
- 型
  ```typescript
  export type Env = Map<string, Construct>;
  export type ParamCond = Map<string, Constant>;
  ```
- `$.extend`を使ったコピーをスプレッド構文に変更

やってないこと
- plot_line_map_control.tsの`{ [key: number]: PlotLine }`（担当の人にやってもらう）
- hydat.tsの`{ [key: string]: HydatほげRaw }`（`JSON.parse`しただけのものを入れておくため）