### PR TITLE
escape 処理を行って innerHTML へ代入するのを innerText へ代入するようにリファクタ

### DIFF
--- a/src/editor/hylagi.ts
+++ b/src/editor/hylagi.ts
@@ -161,14 +161,12 @@ export function renderOutput(response: ResponseBody) {
         firstScriptElement.parentNode!.insertBefore(newScript, firstScriptElement)
       );
     }
-  } else {
-    const getEscapedStringForHTML = (origString: string) =>
-      origString.replace(/\n/gm, '<br/>').replace(/\s/gm, '&nbsp;');
+  } else { // html モードにチェックが入っていない場合は，プレーンテキストで表示する
     if (response.stdout != undefined) {
-      output.innerHTML += getEscapedStringForHTML(response.stdout);
+      output.innerText = response.stdout;
     }
     if (response.stderr != undefined) {
-      output.innerHTML += getEscapedStringForHTML(response.stderr);
+      output.innerText += response.stderr;
     }
   }
 }


### PR DESCRIPTION
(web)hydla の仕様を理解していないので，もしかしたら変なことをやっているかも知れない．
- ビルドできるのは確認したけど，UI を立ち上げてのテストはしていない．

どうやら，「html 表示チェックボックス」みたいなものがあって，これにチェックを「入れない」と，プレーンテキストで表示する様子（推測）．
ここで，従来のコードではわざわざ自前で escape 処理をしていたが，innerText に代入することにしてしまえば，
- 自前の escape 処理が不要
- （ブラウザにとってより効率的でセキュリティ的にも安心．まぁまず関係ないけど）
になる．

はず．