### PR TITLE
parse.ts の正規表現を用いたテスト関数を eta 変換

### DIFF
--- a/src/hydat/parse.ts
+++ b/src/hydat/parse.ts
@@ -1,5 +1,5 @@
-const isAlpha = RegExp.prototype.test.bind(/^[A-Za-z]$/);
-const isDigit = RegExp.prototype.test.bind(/^[0-9]$/);
+const isAlpha = (c: string) => /^[A-Za-z]$/.test(c);
+const isDigit = (c: string) => /^[0-9]$/.test(c);
 
 const isAlDig = (c: string) => isAlpha(c) || isDigit(c);
 

--- a/src/hydat/parse.ts
+++ b/src/hydat/parse.ts
@@ -1,25 +1,17 @@
-export function isAlpha(c: string) {
-  const regex = new RegExp('^[A-Za-z]$');
-  return regex.test(c);
-}
+const isAlpha = new RegExp('^[A-Za-z]$').test;
+const isDigit = new RegExp('^[0-9]$').test;
 
-export function isDigit(c: string) {
-  const regex = new RegExp('^[0-9]$');
-  return regex.test(c);
-}
+const isAlDig = (c: string) => isAlpha(c) || isDigit(c);
 
-export function isAlDig(c: string) {
-  return isAlpha(c) || isDigit(c);
-}
-
-/*
- * <expression> ::= <term> { +<term> | -<term> }
- * <term> ::= <term2> { *<term2> | /<term2> }
- * <term2> ::= <factor> { ^<factor> }
+/* 
+ * <expression> ::= <term> { + <term> | - <term> }
+ * <term> ::= <term2> { * <term2> | / <term2> }
+ * <term2> ::= <factor> { ^ <factor> }
  * <factor> ::= (<expression>) | Func[<expression>] | <negative>
  * <negative> ::= { - } <leaf>
  * <leaf> ::= 'Infinity' | parameter | constant | variable | number
  */
+
 
 export function number(s: string, index: number): [Constant, number] {
   let n = 0;

--- a/src/hydat/parse.ts
+++ b/src/hydat/parse.ts
@@ -1,5 +1,5 @@
-const isAlpha = new RegExp('^[A-Za-z]$').test;
-const isDigit = new RegExp('^[0-9]$').test;
+const isAlpha = RegExp.prototype.test.bind(/^[A-Za-z]$/);
+const isDigit = RegExp.prototype.test.bind(/^[0-9]$/);
 
 const isAlDig = (c: string) => isAlpha(c) || isDigit(c);
 


### PR DESCRIPTION
parse.ts をほんのちょっとだけリファクタした．
- ビルドできるのは確認したけど，実際に動かしてテストしたりとかはしていない．


やったのは，単純に
```typescript
export function isAlpha(c: string) {
  const regex = new RegExp('^[A-Za-z]$');
  return regex.test(c);
}
```
を
```typescript
const isAlpha = new RegExp('^[A-Za-z]$').test;
```
にしただけ（4 行 → 1 行．いえぇい）．

typescript 詳しくないけど，メソッド（だよね？）も普通に eta 変換できるみたいだ（そりゃそうか）
