### PR TITLE
refine colours

### DIFF
--- a/src/graph/datGUI.ts
+++ b/src/graph/datGUI.ts
@@ -75,6 +75,7 @@ export function initDatGUIState(plotSettings: PlotSettings) {
   datGUI
     .addColor(plotSettings, 'backgroundColor')
     .name('background')
+    .setValue('#101010')
     .onChange((value) => {
       setBackgroundColor(value);
       PlotSettingsControl.saveToWebStorage(); /*renderThreeJs();i*/

--- a/static/css/main.css
+++ b/static/css/main.css
@@ -2,6 +2,8 @@ html, body{
 	height: 100%;
 	width: 100%;
 	overflow-x: hidden;
+	background-color: #222;
+	color: #bbb;
 }
 
 
@@ -13,7 +15,6 @@ html, body{
 	display: block;
 	position: static;
 	font-family: Arial, Helvetica, sans-serif;
-	color: #000000;
 	text-align: center;
 	margin: 30px;
 }
@@ -40,12 +41,12 @@ html, body{
 	right: 0;
 	margin: auto;
 	height: 500px;
-	width: 80%;
+	width: 95%;
 }
 #menu_bar {
 	position: relative;
 	height: 50px;
-	background-color: #000;
+	background-color: #111;
 	padding: 6px;
 	border-top-left-radius: 5px;
 	border-top-right-radius: 5px;
@@ -65,7 +66,7 @@ html, body{
 #simulation_settings {
 	position: relative;
 	display: inline-flex;
-	background-color: black;
+	background-color: #111;
 	color: white;
 	max-height: 100px;
 	width: 100%;
@@ -89,11 +90,12 @@ html, body{
 	font-size: initial!important;
 	margin: initial!important;
 	margin-left: 5px!important;
-	padding: initial!important;
+	padding: 3px!important;
 	box-shadow: initial!important;
 	box-sizing: initial!important;
 	transition: initial!important;
 	color: white !important;
+	text-align: right;
 }
 #other_options {
 	width: 120px!important;
@@ -165,7 +167,7 @@ input[type="checkbox"] {
 	-webkit-transform: translateY(-50%) translateX(-50%);
   	transform: translateY(-50%) translateX(-50%);
 
-  	background-color: black;
+  	background-color: #222;
   	border-radius: 30px;
   	padding: 20px;
   	/*padding: 10px;*/


### PR DESCRIPTION
[main.css](https://github.com/HydLa/webHydLa/blob/develop/static/css/main.css) を少しだけいじりました．
- 研究をする上で結構触ると思うので，ちょっとだけ目に優しくしました（つもりです）．

## 主な変更点
1. 背景色を少し改造．背景色が真っ白になっていたが，全体の調和性と見やすさを鑑みて，ダークテーマ風にしました．それに合わせて，文字の色を白（っぽく）にしました．**これによって見えなくなっていたりする部分がないかどうかの確認をお願いします．**
2. エディタの幅を少し増やしました（80% → 95%）．その方が書きやすいんじゃないかなぁと思って．

## 補足
個人的にはもっと改良したい（けど，研究する方が優先度が高いのでまぁやらないでおく）．
（デザイン全般）個人の主観なので，気に入らなかったらそっとクローズしておいてください．
