### PR TITLE
set nd-mode checkbox checked not in ts/js but in html

### DIFF
--- a/src/graph/datGUI.ts
+++ b/src/graph/datGUI.ts
@@ -107,9 +107,6 @@ export function initDatGUIState(plotSettings: PlotSettings) {
   datContainerB.style.height = heightArea;
   datContainerB.appendChild(datGUIAnimate.domElement);
 
-  const ndModeCheckBox = <HTMLInputElement>document.getElementById('nd_mode_check_box');
-  ndModeCheckBox.checked = true;
-
   fixLayout();
 }
 

--- a/static/index.html
+++ b/static/index.html
@@ -137,8 +137,7 @@
 					<div class="each_option">Options: <input id="other_options" type="text" class="options_input" value=""></div>
 					<div class="each_option">Time Out: <input id="timeout_option" type="number" class="options_input" value=30>
 					</div>
-					<!-- nd_mode_check_box はmain.jsの中でデフォルトで"checked"になっている -->
-					<div class="each_option">ND mode: <input id="nd_mode_check_box" type="checkbox" class="options_checkbox">
+					<div class="each_option">ND mode: <input id="nd_mode_check_box" type="checkbox" class="options_checkbox" checked>
 					</div>
 					<div class="each_option">HTML mode: <input id="html_mode_check_box" type="checkbox" class="options_checkbox">
 					</div>


### PR DESCRIPTION
# set nd-mode checkbox checked not in ts/js but in html

## 背景
nd-mode のチェックボックスをデフォルトで checked にするのに，従来は ts/js を用いていた．
https://github.com/HydLa/webHydLa/blob/9a1bbfb9f6dcb5d98ebd0c3b0a552360f180a635/src/graph/datGUI.ts#L110-L111

が，上記コードは，webhydla のグラフエリアの左側に表示している dat.gui のための初期化のコードにいきなり出てきていて，コードの流れとしても美しくないし，何よりわざわざ js でそれをする理由が特には良くわからない．

## 変更点
上記の ts のコードを削除し，
https://github.com/HydLa/webHydLa/blob/9a1bbfb9f6dcb5d98ebd0c3b0a552360f180a635/static/index.html#L140-L141
の input に `checked` 属性を追加した．

