### PR TITLE
remove delete operator

### DIFF
--- a/src/graph/animation.ts
+++ b/src/graph/animation.ts
@@ -456,7 +456,6 @@ export function removePlot(line: PlotLine) {
     for (i = 0; i < line.plot.length; i++) {
       graphState.scene.remove(line.plot[i]);
     }
-    delete line.plot[i];
   }
   animationState.indexArrayMultibimap.deleteKey(line.index);
   line.plot = [];
@@ -466,9 +465,8 @@ function removeMesh(line: THREE.Mesh[] | undefined) {
   if (line !== undefined) {
     for (let i = 0; i < line.length; i++) {
       graphState.scene.remove(line[i]);
-      delete line[i];
     }
-    line.length = 0;
+    line = [];
   }
 }
 


### PR DESCRIPTION
# remove delete operator

`animation.ts` をほんのちょっとだけリファクタ．

## 背景
https://github.com/HydLa/webHydLa/blob/9a1bbfb9f6dcb5d98ebd0c3b0a552360f180a635/src/graph/animation.ts#L459
や
https://github.com/HydLa/webHydLa/blob/9a1bbfb9f6dcb5d98ebd0c3b0a552360f180a635/src/graph/animation.ts#L469
で
`delete` 演算子を用いて，for 文を回しながら，Array の要素を全て削除していた．

が，`delete` 演算子自体，あまり多用するべきものではないと思う．

## 変更点
単に empty な Array を代入するようにした．

```typescript
line = [];
```

こうしても，挙動は変わらないと思うが，（ぼくは `delete` 演算子を使ったことがないため）一応有識者の意見求む．と言ったところ．
