### PR TITLE
Fix #117  Change KeyboardEvent.KeyCode to KeyboardEvent.shiftKey e.t.c.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2547,6 +2547,7 @@
       "integrity": "sha512-gnB85c3MGC7Nm9I/FkiasNBOKjOiO1RNuXXarQms37q4QMpWdlbBgD/VnOStA2faG1dpXMv31RFApjX1/QdgWQ==",
       "dev": true,
       "dependencies": {
+        "colors": "^1.1.2",
         "object-assign": "^4.1.0",
         "string-width": "^4.2.0"
       },
@@ -4856,6 +4857,7 @@
         "minimist": "^1.2.5",
         "neo-async": "^2.6.0",
         "source-map": "^0.6.1",
+        "uglify-js": "^3.1.4",
         "wordwrap": "^1.0.0"
       },
       "bin": {
@@ -5498,6 +5500,9 @@
       "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-2.2.0.tgz",
       "integrity": "sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww==",
       "dev": true,
+      "dependencies": {
+        "is-docker": "^2.0.0"
+      },
       "engines": {
         "node": ">=8"
       },
@@ -5791,6 +5796,7 @@
         "@types/node": "*",
         "anymatch": "^3.0.3",
         "fb-watchman": "^2.0.0",
+        "fsevents": "^2.1.2",
         "graceful-fs": "^4.2.4",
         "jest-regex-util": "^26.0.0",
         "jest-serializer": "^26.6.2",
@@ -10416,8 +10422,10 @@
       "integrity": "sha512-9P3MWk6SrKjHsGkLT2KHXdQ/9SNkyoJbabxnKOoJepsvJjJG8uYTR3yTPxPQvNDI3w4Nz1xnE0TLHK4RIVe/MQ==",
       "dev": true,
       "dependencies": {
+        "chokidar": "^3.4.1",
         "graceful-fs": "^4.1.2",
-        "neo-async": "^2.5.0"
+        "neo-async": "^2.5.0",
+        "watchpack-chokidar2": "^2.0.1"
       },
       "optionalDependencies": {
         "chokidar": "^3.4.1",

--- a/src/UI/newUI.ts
+++ b/src/UI/newUI.ts
@@ -34,7 +34,7 @@ export class NewUI {
 
     document.addEventListener('keydown', (e) => {
       if (!e) return;
-      if (e.keyCode === keyShift || e.keyCode === keyCtr || e.keyCode === keyAlt || e.keyCode === keyMetaL) {
+      if (e.shiftKey || e.ctrlKey || e.altKey || e.metaKey) {
         this.enableZoom(controls);
         $('#scroll-message').css('opacity', '0');
       }
@@ -42,7 +42,7 @@ export class NewUI {
 
     document.addEventListener('keyup', (e) => {
       if (!e) return;
-      if (e.keyCode === keyShift || e.keyCode === keyCtr || e.keyCode === keyAlt || e.keyCode === keyMetaL) {
+      if (e.shiftKey || e.ctrlKey || e.altKey || e.metaKey) {
         this.disableZoom(controls);
       }
     });


### PR DESCRIPTION
deprecated になっていた KeyboardEvant.KeyCode を推奨されている KeyboardEvent.shiftKey 等に変更した。

https://github.com/HydLa/webHydLa/blob/b407d8b7215ff3fac3b45e3f2a35b7425e6b86a9/src/UI/newUI.ts#L40
https://github.com/HydLa/webHydLa/blob/b407d8b7215ff3fac3b45e3f2a35b7425e6b86a9/src/UI/newUI.ts#L48

変更したのは上記 2 箇所の if 文内である。
各プロパティは `true` or `false` の値を取っている。