### PR TITLE
fix issue #126

### DIFF
--- a/src/graph/plotLine.ts
+++ b/src/graph/plotLine.ts
@@ -55,11 +55,11 @@ export class PlotLine {
     this.folder.add(this.settings, 'remove');
 
     this.xItem = this.folder.add(this.settings, 'x');
-    this.xItem.onChange(getUpdateFunction(this, this.xItem));
+    this.xItem.onFinishChange(getUpdateFunction(this, this.xItem));
     this.yItem = this.folder.add(this.settings, 'y');
-    this.yItem.onChange(getUpdateFunction(this, this.yItem));
+    this.yItem.onFinishChange(getUpdateFunction(this, this.yItem));
     this.zItem = this.folder.add(this.settings, 'z');
-    this.zItem.onChange(getUpdateFunction(this, this.zItem));
+    this.zItem.onFinishChange(getUpdateFunction(this, this.zItem));
   }
 }
 


### PR DESCRIPTION
fix #126 
plotLine.ts 内のプロットする変数名の読み取り部において、onChange→onFinishChangeへ書き換えました
webHydLaの変数名の指定において、エンター入力やカーソルをテキストボックスから外すことによって
変数名の判定を行うようになりました。（一文字入力ごとのエラー出力がなくなりました）