### PR TITLE
fix deprecated

### DIFF
--- a/src/graph/plot.ts
+++ b/src/graph/plot.ts
@@ -212,7 +212,6 @@ function getRangesOfFrustum(camera: THREE.OrthographicCamera): ComparableTriplet
 
   graphState.camera.updateMatrix(); // make sure camera's local matrix is updated
   graphState.camera.updateMatrixWorld(); // make sure camera's world matrix is updated
-  graphState.camera.matrixWorldInverse.getInverse(graphState.camera.matrixWorld);
 
   let frustum = new THREE.Frustum();
   frustum.setFromProjectionMatrix(

--- a/src/main.ts
+++ b/src/main.ts
@@ -10,7 +10,7 @@ import { initExample } from './editor/example';
 import { initHydatState } from './hydat/hydat';
 import { initStorage, loadHydlaFromStorage, loadHydatFromStorage } from './storage';
 
-$(document).ready(() => {
+$(() => {
   const savedHydla = loadHydlaFromStorage();
   const savedHydat = loadHydatFromStorage();
 


### PR DESCRIPTION
https://github.com/HydLa/webHydLa/blob/7947f8d8666aa732c89060214c59584b2edf8a56/src/main.ts#L13
ここはそもそも `(document).ready` 自体が不要で、`$(handle)` の形で充分とのこと。

https://github.com/HydLa/webHydLa/blob/7947f8d8666aa732c89060214c59584b2edf8a56/src/graph/plot.ts#L215
ここは `getInverse` メソッドが remove されており、何も実行していない行なので削除した。