### PR TITLE
fix parameter bar

### DIFF
--- a/src/graph/datGUI.ts
+++ b/src/graph/datGUI.ts
@@ -144,6 +144,8 @@ export function parameterSetting(pars: Map<string, HydatParameter>) {
     const lower = par.lowerBound.value.getValue(new Map());
     const upper = par.upperBound.value.getValue(new Map());
 
+    // パラメタの上下限がどちらも設定されていなければ, それぞれ 100, -100 で決め打ち
+    // 決め打ちの値を変更したくば, ここをいじるべし！
     let minParValue = -100;
     let maxParValue = 100;
     if (isFinite(lower) || isFinite(upper)) {

--- a/src/graph/datGUI.ts
+++ b/src/graph/datGUI.ts
@@ -144,14 +144,13 @@ export function parameterSetting(pars: Map<string, HydatParameter>) {
     const lower = par.lowerBound.value.getValue(new Map());
     const upper = par.upperBound.value.getValue(new Map());
 
-    // パラメタの下限と上限の少なくとも1つは有限な値であること
-    if (!isFinite(lower) && !isFinite(upper)) {
-      throw new Error('Error: at least one of lowerBound and upperBound must be finite.');
+    let minParValue = -100;
+    let maxParValue = 100;
+    if (isFinite(lower) || isFinite(upper)) {
+      // 下限値が有限でなければ, 上限値-100を下限値とする(上限値も然り)
+      minParValue = isFinite(lower) ? lower : upper - 100;
+      maxParValue = isFinite(upper) ? upper : lower + 100;
     }
-
-    // 下限値が有限でなければ, 上限値-100を下限値とする(上限値も然り)
-    const minParValue = isFinite(lower) ? lower : upper - 100;
-    const maxParValue = isFinite(upper) ? upper : lower + 100;
     const step = (maxParValue - minParValue) / 100;
 
     DatGUIState.plotSettings.parameterCondition.set(key, new ParameterCondition(minParValue, maxParValue));


### PR DESCRIPTION
上限及び下限が設定されていないパラメータが存在したとき、エラーが起きて描画されていなかったバグを修正。
上記の場合、下限値を `-100` 上限値を `100` として描画させることに現在なっている。
もしこの値を変えたければ下記の部分を変更するべし。
https://github.com/HydLa/webHydLa/blob/b9040e4433da72733c03024aec0619ca72b8c4d0/src/graph/datGUI.ts#L147-L150