### PR TITLE
fix error of variable name

### DIFF
--- a/src/graph/animation.ts
+++ b/src/graph/animation.ts
@@ -371,7 +371,7 @@ export function dfsEachLine(
       if (finished) return;
     }
   } catch (ex) {
-    if (ex instanceof TypeError) {
+    if (ex instanceof Error) {
       console.log(ex);
       console.log(ex.stack);
       showToast(`Plot failed: ${ex.name}(${ex.message})`, 3000, 'red darken-4');


### PR DESCRIPTION
https://github.com/HydLa/webHydLa/blob/2a55f247c019bd1a201b4cb4be332e37825e35c3/src/graph/animation.ts#L373-L381
変数名に存在しないものを記述したときにはここでエラーをキャッチしているが、エラーの型が `TypeError` でなかったのが今回のバグの要因である。
実際には `Error` の型で投げられるため、それをキャッチするように変更したら正しく動作した。