### PR TITLE
fix bug

### DIFF
--- a/src/UI/newUI.ts
+++ b/src/UI/newUI.ts
@@ -37,7 +37,7 @@ export class NewUI {
 
     document.addEventListener('keydown', (e) => {
       if (!e) return;
-      if (e.shiftKey || e.ctrlKey || e.altKey || e.metaKey) {
+      if (e.key === 'Shift' || e.key === 'Control' || e.key === 'Alt' || e.key === 'Meta') {
         this.enableZoom(controls);
         $('#scroll-message').css('opacity', '0');
       }
@@ -45,7 +45,7 @@ export class NewUI {
 
     document.addEventListener('keyup', (e) => {
       if (!e) return;
-      if (e.shiftKey || e.ctrlKey || e.altKey || e.metaKey) {
+      if (e.key === 'Shift' || e.key === 'Control' || e.key === 'Alt' || e.key === 'Meta') {
         this.disableZoom(controls);
       }
     });

--- a/src/graph/datGUI.ts
+++ b/src/graph/datGUI.ts
@@ -110,8 +110,8 @@ export function initDatGUIState(plotSettings: PlotSettings) {
   // フォルダの追加
   DatGUIState.parameterFolder = datGUI.addFolder('parameters');
   DatGUIState.parameterFolderSeek = datGUIAnimate.addFolder('seek');
-  datGUI.add(addLineObj, 'add').name('add new line');
   DatGUIState.variableFolder = datGUI.addFolder('variables');
+  datGUI.add(addLineObj, 'add').name('add new line');
 
   // 上
   const datContainer = document.getElementById('dat-gui')!;


### PR DESCRIPTION
Shift を 1 度押せばその後 Shift を離しても zoom in/out ができるというバグを修正。
及び、add new line bar の位置修正。

https://github.com/HydLa/webHydLa/blob/b0a049f88164a07590f9e47749cf4aeb3f915e3b/src/UI/newUI.ts#L46-L51
ここで `keyup` イベントのときには Shift を離してしまっているので、 `e.keyShift` が `false` となってしまう結果このバグが生じていた。
Ctrl, Alt, Meta に対しても同様である。

これを `e.keyShift === 'Shift'` 等に変更することで正しく動作するようになった。

add new line bar に関しては variable の上にあったが、変更後は variable の下に来るようにした。