### PR TITLE
#156 fix consistency of ball and line color

### DIFF
--- a/src/graph/animation.ts
+++ b/src/graph/animation.ts
@@ -1,6 +1,7 @@
 /**
  * webHydLa の下部のグラフの描画を行う
  */
+import { Console } from 'console';
 import * as THREE from 'three';
 import { mergeBufferGeometries } from 'three/examples/jsm/utils/BufferGeometryUtils';
 
@@ -131,7 +132,7 @@ function addPlot(line: PlotLine) {
 }
 
 /**
- * ???
+ * fixed が false の時に指定された本数（= n）のグラフを生成するために, 各パラメタの値を n 分割して各グラフに割り当てる
  */
 function divideParameter(parameterMap: Map<string, HydatParameter>) {
   let nowParameterConditionList: ParamCond[] = [new Map()];
@@ -374,10 +375,10 @@ function makeLine(points: THREE.Vector3[], material: THREE.Material, segments = 
 /**
  * animationState に球を追加する
  */
-function addSphere(currentParamIdx: number, color: number[]) {
+function addSphere(color: number) {
   const sGeometry = new THREE.SphereBufferGeometry(0.1);
-  const sphere = new THREE.Mesh(sGeometry, new THREE.MeshBasicMaterial({ color: color[currentParamIdx] }));
-  sphere.position.set(0, 0, 0);
+  const sphere = new THREE.Mesh(sGeometry, new THREE.MeshBasicMaterial({ color: color }));
+  sphere.position.set(0, animationState.array, 0);
   graphState.scene.add(sphere);
   animationState.plotAnimate[animationState.array] = sphere;
 }
@@ -417,7 +418,7 @@ export function dfsEachLine(
       if (phase.children.length == 0) {
         // on leaves
         addLine(currentLineVec, color[currentParamIdx], line, width);
-        addSphere(currentParamIdx, color);
+        addSphere(color[currentParamIdx]);
 
         currentLineVec = [];
         animationState.currentLineVecAnimation = [];
@@ -537,12 +538,12 @@ export function removePlot(line: PlotLine) {
   line.plot = [];
 }
 
-function removeMesh(line: THREE.Mesh[] | undefined) {
-  if (line !== undefined) {
-    for (let i = 0; i < line.length; i++) {
-      graphState.scene.remove(line[i]);
+function removeMesh(spheres: THREE.Mesh[] | undefined) {
+  if (spheres !== undefined) {
+    for (let i = 0; i < spheres.length; i++) {
+      graphState.scene.remove(spheres[i]);
     }
-    line = [];
+    spheres = [];
   }
 }
 
@@ -731,6 +732,7 @@ export function animate() {
         sphere.material.color.set(animationState.animationLine[arr].color);
       }
       if (animationState.time > animationState.animationLine[arr].vecs.length - 1) {
+        animationState.plotAnimate[arr] = sphere;
         arr++;
         continue;
       }

--- a/src/graph/datGUI.ts
+++ b/src/graph/datGUI.ts
@@ -165,7 +165,7 @@ export function parameterSetting(pars: Map<string, HydatParameter>) {
       .add(DatGUIState.plotSettings.parameterCondition.get(key)!, 'value', minParValue, maxParValue)
       .name(key);
     parameterItem.onChange(() => {
-      if(!DatGUIState.fixedChange){
+      if (!DatGUIState.fixedChange) {
         replotAll();
       }
     });

--- a/src/graph/datGUI.ts
+++ b/src/graph/datGUI.ts
@@ -22,6 +22,9 @@ export class DatGUIState {
 
   /** 描画設定用のデータ構造 */
   static plotSettings: PlotSettings;
+
+  /** fixed の直前と現在の状態 */
+  static fixedChange: boolean;
 }
 
 /**
@@ -122,6 +125,7 @@ export function initDatGUIState(plotSettings: PlotSettings) {
   datContainerB.style.height = heightArea;
   datContainerB.appendChild(datGUIAnimate.domElement);
 
+  DatGUIState.fixedChange = false;
   fixLayout();
 }
 
@@ -161,7 +165,9 @@ export function parameterSetting(pars: Map<string, HydatParameter>) {
       .add(DatGUIState.plotSettings.parameterCondition.get(key)!, 'value', minParValue, maxParValue)
       .name(key);
     parameterItem.onChange(() => {
-      replotAll();
+      if(!DatGUIState.fixedChange){
+        replotAll();
+      }
     });
     parameterItem.step(step);
 
@@ -177,8 +183,9 @@ export function parameterSetting(pars: Map<string, HydatParameter>) {
     DatGUIState.parameterItems.push(modeItemRange);
     DatGUIState.parameterItems.push(parameterItem);
 
-    // パラメタのfixedのチェックボックス
+    // パラメタの fixed のチェックボックス. 値が変化した時は parameterItem の onChange は呼び出さないようにする
     modeItemFixed.onChange(() => {
+      DatGUIState.fixedChange = true;
       if (!DatGUIState.plotSettings.parameterCondition!.get(key)!.fixed) {
         parameterItem.min(1).max(100).step(1).setValue(5);
       } else {
@@ -188,6 +195,7 @@ export function parameterSetting(pars: Map<string, HydatParameter>) {
           .step(step)
           .setValue((minParValue + maxParValue) / 2);
       }
+      DatGUIState.fixedChange = false;
       replotAll();
     });
     // パラメタのrangeのチェックボックス

--- a/src/graph/plotLine.ts
+++ b/src/graph/plotLine.ts
@@ -95,11 +95,10 @@ export function getUpdateFunction(plotLine: PlotLine, item: dat.GUIController) {
 export function updateFolder(plotLine: PlotLine, succeeded: boolean) {
   if (succeeded) {
     const colorOnCorrect = '#303030';
-    (<HTMLInputElement>plotLine.xItem.domElement.firstChild).style.backgroundColor = (<HTMLInputElement>(
-      plotLine.yItem.domElement.firstChild
-    )).style.backgroundColor = (<HTMLInputElement>(
-      plotLine.zItem.domElement.firstChild
-    )).style.backgroundColor = colorOnCorrect;
+    (<HTMLInputElement>plotLine.xItem.domElement.firstChild).style.backgroundColor =
+      (<HTMLInputElement>plotLine.yItem.domElement.firstChild).style.backgroundColor =
+      (<HTMLInputElement>plotLine.zItem.domElement.firstChild).style.backgroundColor =
+        colorOnCorrect;
   } else {
     const elm = plotLine.lastEditedInput;
     if (elm === undefined) return;


### PR DESCRIPTION
- fixed のオプション ON/OFF の際, parameterItem の onChange も同時に走ってしまうことでボールが余計に生成されるバグがあったので修正した.
- fixed が false の時は複数のボールが生成されるが, 一部が終点に辿り着いた状況で fixed を true にすると謎の位置にボールが生成され, 新たなボールと新たなグラフの色の整合性が取れなくなっていたので, それを修正した. 原因は終点に辿り着いたボールに対して, animate() の処理は animationState.plotAnimate[<該当のボールの添え字>] が undefined になるようなものだったことであり, 再描画の際ボールのオブジェクトを消せていなかった.